### PR TITLE
fix: Error on dragging slides

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -650,14 +650,10 @@ export default {
           ref: "track",
           onTransitionend: this.onTransitionend,
           onMousedown: this.config.mouseDrag
-            ? function (e) {
-                this.onDragStart(e);
-              }
+            ? this.onDragStart.bind(this)
             : undefined,
           onTouchstart: this.config.mouseDrag
-            ? function (e) {
-                this.onDragStart(e);
-              }
+            ? this.onDragStart.bind(this)
             : undefined,
         },
         slides


### PR DESCRIPTION
fixes the following error on dragging slides

```
TypeError: Cannot read properties of undefined (reading 'onDragStart')
```
