### PR TITLE
fix: add type definitions for noUncheckedSideEffectImports compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       "import": "./dist/index.mjs"
     },
     "./css": {
+      "types": "./src/css.d.ts",
       "import": "./src/index.css",
       "require": "./src/index.css"
     }

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -1,1 +1,1 @@
-export * from "./index.css";
+declare module "@wattanx/hooper-vue3/css" {}


### PR DESCRIPTION
This PR adds type definitions compatible with the `noUncheckedSideEffectImports` compiler option,
which is enabled by default when running `tsc --init` with TypeScript 5.9 and later.

ref: https://devblogs.microsoft.com/typescript/announcing-typescript-5-9-beta/#minimal-and-updated-tsc---init